### PR TITLE
Use Python AST for basic constructions

### DIFF
--- a/mybuild_embox/lang_legacy/lex.py
+++ b/mybuild_embox/lang_legacy/lex.py
@@ -29,11 +29,7 @@ tokens = [
     'LBRACKET', 'RBRACKET',
     'COMMA', 'PERIOD', 'COLON', 'EQUALS',
 
-    #######
-
     'E_AT',
-    'E_WILDCARD',
-
 ]
 
 # Completely ignored characters
@@ -60,6 +56,7 @@ t_COMMA            = r','
 t_PERIOD           = r'\.'
 t_COLON            = r':'
 t_EQUALS           = r'='
+t_E_AT             = r'@'
 
 
 reserved = {
@@ -70,7 +67,6 @@ reserved = {
     'annotation': 'E_ANNOTATION',
     'interface': 'E_INTERFACE',
     'extends': 'E_EXTENDS',
-    'feature': 'E_FEATURE',
     'module': 'E_MODULE',
     'static': 'E_STATIC',
     'abstract': 'E_ABSTRACT',
@@ -91,8 +87,6 @@ reserved = {
 }
 tokens.extend(set(reserved.values()))
 
-t_E_AT = r'@'
-t_E_WILDCARD = r'\.\*'
 
 # Identifiers
 def t_ID(t):

--- a/mybuild_embox/lang_legacy/lex.py
+++ b/mybuild_embox/lang_legacy/lex.py
@@ -26,7 +26,8 @@ tokens = [
     # Delimeters ( ) { } , . $ = ; |
     'LPAREN',   'RPAREN',
     'LBRACE',   'RBRACE',
-    'COMMA', 'PERIOD', 'EQUALS',
+    'LBRACKET', 'RBRACKET',
+    'COMMA', 'PERIOD', 'COLON', 'EQUALS',
 
     #######
 
@@ -57,6 +58,7 @@ def t_RBRACE(t):   r'\}'; t.lexer.ignore_newline_stack.pop();     return t
 # Delimeters
 t_COMMA            = r','
 t_PERIOD           = r'\.'
+t_COLON            = r':'
 t_EQUALS           = r'='
 
 

--- a/mybuild_embox/lang_legacy/lex.py
+++ b/mybuild_embox/lang_legacy/lex.py
@@ -1,6 +1,5 @@
 from _compat import *
 
-from keyword import iskeyword
 import ast
 
 import ply.lex
@@ -95,8 +94,6 @@ def t_ID(t):
     r'\^?[a-zA-Z_][a-zA-Z_0-9]*'
     t.type = reserved.get(t.value,'ID')    # Check for reserved words
     t.value = t.value.lstrip('^')
-    if iskeyword(t.value):
-        t.value += '_'
     return t
 
 # A regular expression rule with some action code

--- a/mybuild_embox/lang_legacy/lex.py
+++ b/mybuild_embox/lang_legacy/lex.py
@@ -84,6 +84,8 @@ reserved = {
     # this way, configuration == module
     'configuration': 'E_MODULE',
     'include': 'E_DEPENDS',
+
+    '__my_debug_print__': 'E_PRINT',
 }
 tokens.extend(set(reserved.values()))
 

--- a/mybuild_embox/lang_legacy/parse.py
+++ b/mybuild_embox/lang_legacy/parse.py
@@ -123,10 +123,22 @@ def py_eval(p, expr, **self_arg_value):
 @rule
 def p_my_file(p, package, imports, entities):
     """
-    my_file : package imports entities
+    my_file : package imports entities debug
     """
     # print package
     return dict(entities)
+
+@rule
+def p_debug(p, expr=-1):
+    """
+    debug : E_PRINT expr
+    """
+    print(py_eval(p, expr, parser=p.parser), file=sys.stderr)
+
+def p_nodebug(p):
+    """
+    debug :
+    """
 
 # package?
 @rule

--- a/mybuild_embox/lang_legacy/parse.py
+++ b/mybuild_embox/lang_legacy/parse.py
@@ -554,33 +554,19 @@ def p_error(t):
 
 @rule
 def p_test(p, test):
-    """test : pytest
-       test : mystub"""
+    """test : pytest"""
     return test
 
 @rule
 def p_pytest(p, stub, builders):
-    """pytest : pystub trailers
-       pytest : mystub trailers_plus"""
+    """pytest : pystub trailers"""
     return build_chain(builders, stub)
 
 @rule
 def p_stub(p, builder):
     """pystub : name
-       pystub : pyatom
-       mystub : myatom"""
+       pystub : pyatom"""
     return build_node(builder)
-
-
-@rule_wloc
-def p_myatom_typedef(p, metatype, body):
-    """myatom : pytest typebody"""
-    return lambda: build_typedef(p, body, metatype)
-
-@rule_wloc
-def p_myatom_typedef_named(p, metatype, qualname, mb_call_builder, body):
-    """myatom : pytest qualname mb_call typebody"""
-    return lambda: build_typedef(p, body, metatype, qualname, mb_call_builder)
 
 
 @rule_wloc
@@ -632,9 +618,7 @@ def p_dictent(p, key, value=3):
 
 @rule
 def p_trailer_call(p, call):
-    """trailer : call
-       mb_call : call
-       mb_call : empty"""
+    """trailer : call"""
     return call
 
 @rule_wloc

--- a/mybuild_embox/lang_legacy/parse.py
+++ b/mybuild_embox/lang_legacy/parse.py
@@ -381,29 +381,21 @@ def p_empty_modifier_none(p):
     """
     module_modifier :
     """
-    func = prepare_property(p, '[tool.cc, tool.gen_headers]')
-    ns = dict(tools=cached_property(func, attr='tools'))
-    return core.Module, ns
+    return core.Module, {}
 
 @rule
 def p_module_modifier_abstract(p, value):
     """
     module_modifier :  E_ABSTRACT
     """
-    func = prepare_property(p, '[]')
-    ns = dict(tools=cached_property(func, attr='tools'))
-    return core.InterfaceModule, ns
+    return core.InterfaceModule, {}
 
 @rule
 def p_module_modifier_static(p, value):
     """
     module_modifier : E_STATIC
     """
-    func = prepare_property(p, '[tool.cc_lib, tool.gen_headers]')
-    static = prepare_property(p, 'True')
-    ns = dict(tools=cached_property(func, attr='tools'),
-              isstatic=cached_property(static, attr='isstatic'))
-    return core.Module, ns
+    return core.Module, {'isstatic': True}
 
 @rule
 def p_simple_value(p, value):

--- a/mybuild_embox/lang_legacy/parse.py
+++ b/mybuild_embox/lang_legacy/parse.py
@@ -1,3 +1,8 @@
+from __future__ import print_function
+
+from _compat import *
+
+
 import ast
 import itertools
 import sys
@@ -549,5 +554,5 @@ module sched_ticker_preempt extends sched_ticker {
 }
 """
     res = my_parse(source, debug=0)
-    print res
+    print(res)
 

--- a/mybuild_embox/lang_legacy/parse.py
+++ b/mybuild_embox/lang_legacy/parse.py
@@ -1,5 +1,6 @@
 import ast
 import itertools
+import sys
 from collections import defaultdict
 from operator import itemgetter
 

--- a/mybuild_embox/lang_legacy/parse.py
+++ b/mybuild_embox/lang_legacy/parse.py
@@ -511,7 +511,7 @@ def p_error(t):
         raise MySyntaxError("Premature end of file")
 
 parser = ply.yacc.yacc(start='my_file',
-                       # errorlog=ply.yacc.NullLogger(), debug=False,
+                       errorlog=ply.yacc.NullLogger(), debug=False,
                        write_tables=False)
 
 def my_parse(source, filename="<unknown>", module_globals=None, **kwargs):

--- a/mybuild_embox/lang_legacy/parse.py
+++ b/mybuild_embox/lang_legacy/parse.py
@@ -538,21 +538,7 @@ def my_parse(source, filename="<unknown>", module_globals=None, **kwargs):
 
 if __name__ == "__main__":
     source = """
-package embox.kernel.sched
-
-@DefaultImpl(sched_ticker_preempt)
-abstract module sched_ticker { }
-
-module sched_ticker_preempt extends sched_ticker {
-    source "sched_ticker.c"
-    option number tick_interval = 100
-    option string tick_interval = "xxx"
-    option boolean tick_interval = false
-    @NoRuntime depends embox.kernel.timer.sys_timer /* for timeslices support */
-    @NoRuntime depends embox.kernel.timer /* for timeslices support */
-    depends embox.kernel /* for timeslices support */
-}
-"""
+    """
     res = my_parse(source, debug=0)
     print(res)
 

--- a/mybuild_embox/lang_legacy/parse.py
+++ b/mybuild_embox/lang_legacy/parse.py
@@ -585,19 +585,14 @@ def p_string(p, s):
     return lambda: ast.Str(s)
 
 @rule_wloc
-def p_pyatom_parens_or_tuple(p, exprlist=2):  # (item, ...)
-    """pyatom : LPAREN exprlist RPAREN"""
+def p_pyatom_parens_or_tuple(p, opentok, exprlist):  # (item, ...), [item, ...]
+    """pyatom : LPAREN   exprlist RPAREN
+       pyatom : LBRACKET exprlist RBRACKET"""
     expr_l, expr_el = exprlist
-    if expr_el is not None:
+    if opentok == '(' and expr_el is not None:
         return lambda: expr_el
     else:
-        return lambda: ast.Tuple(expr_l, ast.Load())
-
-@rule_wloc
-def p_pyatom_list(p, exprlist=2):  # [item, ...]
-    """pyatom : LBRACKET exprlist RBRACKET"""
-    expr_l = exprlist[0]
-    return lambda: ast.List(expr_l, ast.Load())
+        return lambda: ast.List(expr_l, ast.Load())
 
 @rule_wloc
 def p_pyatom_dict(p, kv_pairs=2):  # [key: value, ...], [:]

--- a/mybuild_embox/lang_legacy/parse.py
+++ b/mybuild_embox/lang_legacy/parse.py
@@ -553,13 +553,13 @@ def p_error(t):
 # =================================================
 
 @rule
-def p_test(p, test):
-    """test : pytest"""
-    return test
+def p_expr(p, expr):
+    """expr : pyexpr"""
+    return expr
 
 @rule
-def p_pytest(p, stub, builders):
-    """pytest : pystub trailers"""
+def p_pyexpr(p, stub, builders):
+    """pyexpr : pystub trailers"""
     return build_chain(builders, stub)
 
 @rule
@@ -585,19 +585,19 @@ def p_string(p, s):
     return lambda: ast.Str(s)
 
 @rule_wloc
-def p_pyatom_parens_or_tuple(p, testlist=2):  # (item, ...)
-    """pyatom : LPAREN testlist RPAREN"""
-    test_l, test_el = testlist
-    if test_el is not None:
-        return lambda: test_el
+def p_pyatom_parens_or_tuple(p, exprlist=2):  # (item, ...)
+    """pyatom : LPAREN exprlist RPAREN"""
+    expr_l, expr_el = exprlist
+    if expr_el is not None:
+        return lambda: expr_el
     else:
-        return lambda: ast.Tuple(test_l, ast.Load())
+        return lambda: ast.Tuple(expr_l, ast.Load())
 
 @rule_wloc
-def p_pyatom_list(p, testlist=2):  # [item, ...]
-    """pyatom : LBRACKET testlist RBRACKET"""
-    test_l = testlist[0]
-    return lambda: ast.List(test_l, ast.Load())
+def p_pyatom_list(p, exprlist=2):  # [item, ...]
+    """pyatom : LBRACKET exprlist RBRACKET"""
+    expr_l = exprlist[0]
+    return lambda: ast.List(expr_l, ast.Load())
 
 @rule_wloc
 def p_pyatom_dict(p, kv_pairs=2):  # [key: value, ...], [:]
@@ -612,7 +612,7 @@ def p_pyatom_dict(p, kv_pairs=2):  # [key: value, ...], [:]
 
 @rule
 def p_dictent(p, key, value=3):
-    """dictent : test COLON test"""
+    """dictent : expr COLON expr"""
     return key, value
 
 
@@ -647,12 +647,12 @@ def p_call(p, kw_arg_pairs=2):  # x(arg, kw=arg, ...)
 
 @rule
 def p_argument_pos(p, value):
-    """argument : test"""
+    """argument : expr"""
     return None, value
 
 @rule
 def p_argument_kw(p, key, value=3):
-    """argument : ID EQUALS test"""
+    """argument : ID EQUALS expr"""
     kw_wloc = key, ploc(p)
     return kw_wloc, value
 
@@ -664,30 +664,30 @@ def p_trailer_attr_or_name(p, name=-1):  # x.attr or name
 
 @rule_wloc
 def p_trailer_item(p, item=2):  # x[item]
-    """trailer : LBRACKET test RBRACKET"""
+    """trailer : LBRACKET expr RBRACKET"""
     return lambda expr: ast.Subscript(expr, ast.Index(item), ast.Load())
 
 
-# testlist is a pair of [list of elements] and a single element (if any)
+# exprlist is a pair of [list of elements] and a single element (if any)
 
 @rule
-def p_testlist(p, l):
-    """testlist : testlist_plus mb_comma"""
+def p_exprlist(p, l):
+    """exprlist : exprlist_plus mb_comma"""
     return l
 
 @rule
-def p_testlist_empty(p):
-    """testlist :"""
+def p_exprlist_empty(p):
+    """exprlist :"""
     return [], None
 
 @rule
-def p_testlist_single(p, el):
-    """testlist_plus : test"""
+def p_exprlist_single(p, el):
+    """exprlist_plus : expr"""
     return [el], el
 
 @rule
-def p_testlist_list(p, l_el, el=-1):
-    """testlist_plus : testlist_plus COMMA test"""
+def p_exprlist_list(p, l_el, el=-1):
+    """exprlist_plus : exprlist_plus COMMA expr"""
     l, _ = l_el
     l.append(el)
     return l, None

--- a/mybuild_embox/lang_legacy/parse.py
+++ b/mybuild_embox/lang_legacy/parse.py
@@ -108,16 +108,6 @@ def p_package(p, qualified_name=-1):
     """
     return qualified_name
 
-# import*
-@rule
-def p_imports(p):
-    """
-    imports : import imports
-    import : E_IMPORT qualified_name_with_wildcard
-    """
-    raise NotImplementedError("Imports are not supported",
-                              ploc(p))
-
 @rule
 def p_annotated_type(p, annotations, member_type):
     """
@@ -145,83 +135,21 @@ def p_type_module(p, module):
     """
     return module
 
-@rule
-def p_type_interface(p, interface):
-    """
-    type : interface
-    """
-    raise NotImplementedError("Interfaces and features are not supported",
-                              ploc(p))
-
 # -------------------------------------------------
 # annotation type.
-# -------------------------------------------------
-
-@rule
-def p_annotation_type(p):
-    """
-    type : annotation_type
-    annotation_type : E_ANNOTATION ID LBRACE annotation_members RBRACE
-    annotation_members : annotated_annotation_member annotation_members
-    annotation_members :
-    annotated_annotation_member : annotations option
-    """
-    raise NotImplementedError("Annotations are not supported",
-                              ploc(p))
-
-
-# -------------------------------------------------
 # interfaces and features.
+# import.
 # -------------------------------------------------
 
-# interface name (extends ...)? { ... }
 @rule
-def p_interface(p):
+def p_not_implemented(p, kind):
     """
-    interface : E_INTERFACE ID super_interfaces LBRACE features RBRACE
+    type : E_ANNOTATION ID
+    type : E_INTERFACE ID
+    import : E_IMPORT
     """
-    raise NotImplementedError("Interfaces and features are not supported",
-                              ploc(p))
-
-# (extends ...)?
-@rule
-def p_super_interfaces(p):
-    """
-    super_interfaces : E_EXTENDS reference_list
-    super_interfaces :
-    """
-    raise NotImplementedError("Interfaces and features are not supported",
-                              ploc(p))
-
-# annotated_interface_member*
-@rule
-def p_features(p):
-    """
-    features : annotated_feature features
-    features :
-    annotated_feature : annotations feature
-    """
-    raise NotImplementedError("Interfaces and features are not supported",
-                              ploc(p))
-
-# feature name (extends ...)?
-@rule
-def p_feature(p):
-    """
-    feature : E_FEATURE ID super_features
-    """
-    raise NotImplementedError("Interfaces and features are not supported",
-                              ploc(p))
-
-# (extends ...)?
-@rule
-def p_super_features(p):
-    """
-    super_features : E_EXTENDS reference_list
-    super_features :
-    """
-    raise NotImplementedError("Interfaces and features are not supported",
-                              ploc(p))
+    raise NotImplementedError("'{kind}' types are not supported"
+                              .format(**locals()), ploc(p))
 
 # -------------------------------------------------
 # modules.
@@ -399,6 +327,7 @@ def p_list_entries(p, entry, entries=-1):
     parameters_list : parameter COMMA parameters_list
     reference_list : reference COMMA reference_list
     reference_wopts_list : reference_wopts COMMA reference_wopts_list
+    imports : import imports
     annotations : annotation annotations
     entities : annotated_type entities
     """
@@ -525,20 +454,6 @@ def p_qualified_name(p, tire, name=-1):
     """
     return tire + '.' + name
 
-@rule
-def p_qualified_name_with_wildcard(p):
-    """
-    qualified_name_with_wildcard : qualified_name E_WILDCARD
-    """
-    raise NotImplementedError("Wildcard names are not supported",
-                              ploc(p))
-
-@rule
-def p_qualified_name_without_wildcard(p, qualified_name):
-    """
-    qualified_name_with_wildcard : qualified_name
-    """
-    return qualified_name
 
 def p_error(t):
     if t is not None:

--- a/mybuild_embox/lang_legacy/parse.py
+++ b/mybuild_embox/lang_legacy/parse.py
@@ -106,7 +106,11 @@ def p_package(p, qualname_wlocs=-1):
     """
     package : E_PACKAGE qualname
     """
-    return '.'.join(name for name, loc in qualname_wlocs)
+    qualname = '.'.join(name for name, loc in qualname_wlocs)
+    expected = p.lexer.module_globals['__package__']
+    if qualname != expected:
+        raise MySyntaxError("Package mismatch, expected '{expected}'"
+                            .format(**locals()), ploc(p, 2))
 
 @rule
 def p_annotated_type(p, annotations, member_type):
@@ -298,7 +302,6 @@ def p_none(p):
     """
     option_default_value :
     super_module :
-    package :
     annotation_initializer :
     """
     return None

--- a/mybuild_embox/lang_legacy/parse.py
+++ b/mybuild_embox/lang_legacy/parse.py
@@ -114,6 +114,10 @@ def py_eval(p, expr, **self_arg_value):
         return func()
 
 
+class module(core.ModuleMetaBase):
+    """An alias with a human-readable name."""
+
+
 @rule
 def p_my_file(p, package, imports, entities):
     """
@@ -230,10 +234,11 @@ def p_module_type(p, modifier, name=3, super_module=4, module_members=-2):
             option.__dict__.update(ns)
         option_types.append((option._name, option))
 
-    meta = module_class._meta_for_base(option_types=option_types)
-    module = meta(name, bases, module_ns)
+    meta = module_class._meta_for_base(option_types=option_types,
+                                       metaclass=module)
+    ret_module = meta(name, bases, module_ns)
 
-    return (name, module)
+    return (name, ret_module)
 
 # (extends ...)?
 @rule

--- a/mybuild_embox/lang_legacy/parse.py
+++ b/mybuild_embox/lang_legacy/parse.py
@@ -533,6 +533,9 @@ def my_parse(source, filename="<unknown>", module_globals=None, **kwargs):
         result = parser.parse(source, lexer=lx, tracking=True, **kwargs)
     except (MySyntaxError, NotImplementedError) as e:
         raise SyntaxError(*e.args)
+    except:
+        print("Unable to parse '{}'".format(filename), file=sys.stderr)
+        raise
 
     return result
 

--- a/mybuild_embox/lang_legacy/parse.py
+++ b/mybuild_embox/lang_legacy/parse.py
@@ -102,11 +102,11 @@ def p_my_file(p, package, imports, entities):
 
 # package?
 @rule
-def p_package(p, qualified_name=-1):
+def p_package(p, qualname_wlocs=-1):
     """
-    package : E_PACKAGE qualified_name
+    package : E_PACKAGE qualname
     """
-    return qualified_name
+    return '.'.join(name for name, loc in qualname_wlocs)
 
 @rule
 def p_annotated_type(p, annotations, member_type):
@@ -372,14 +372,6 @@ def p_module_modifier_static(p, value):
     return core.Module, {'isstatic': True}
 
 @rule
-def p_simple_value(p, value):
-    """
-    qualified_name : ID
-    """
-    return value
-    ['\"' + value + '\"']
-
-@rule
 def p_simple_filename(p, value):
     """
     filename : STRING
@@ -442,17 +434,6 @@ def p_value_bool(p, val):
     value : E_BOOL
     """
     return val == 'true'
-
-
-# -------------------------------------------------
-# extended identifiers.
-# -------------------------------------------------
-@rule
-def p_qualified_name(p, tire, name=-1):
-    """
-    qualified_name : ID PERIOD qualified_name
-    """
-    return tire + '.' + name
 
 
 def p_error(t):

--- a/mybuild_embox/lang_legacy/runtime.py
+++ b/mybuild_embox/lang_legacy/runtime.py
@@ -10,6 +10,8 @@ __date__ = "2015-06-27"
 
 from _compat import *
 
+from util.namespace import Namespace
+
 
 builtin_names = [
     # Functions
@@ -41,3 +43,34 @@ builtin_names = [
 # _compat.* as well), and the rest come from Python builtins.
 builtins = dict((name, eval(name)) for name in builtin_names)
 
+
+annotation_names = [
+    'AddPrefix',                'App',
+    'AutoCmd',                  'Build',
+    'BuildArtifactPath',        'BuildDepends',
+    'Cflags',                   'Cmd',
+    'DefaultImpl',              'DefineMacro',
+    'For',                      'Generated',
+    'IfNeed',                   'Include',
+    'IncludeExport',            'IncludePath',
+    'IncludePathBefore',        'InitFS',
+    'InstrumentProfiling',      'Mandatory',
+    'NoRuntime',                'NumConstraint',
+    'Postbuild',                'Rule',
+    'Runlevel',                 'TestFor',
+    'Type',                     'Unique',
+    'WithAllTests',             'WithTest',
+    'WithValueNumber',
+]
+
+class Annotation(Namespace):
+
+    def __call__(self, *args, **kwargs):
+        cls = type(self)
+        if args:
+            kwargs.update(__my_value__=args[0] if len(args)==1 else list(args))
+        ret = cls(**dict(self.__dict__, **kwargs))
+        return ret
+
+
+builtins.update((name, Annotation(__name__=name)) for name in annotation_names)

--- a/mybuild_embox/lang_legacy/runtime.py
+++ b/mybuild_embox/lang_legacy/runtime.py
@@ -10,6 +10,7 @@ __date__ = "2015-06-27"
 
 from _compat import *
 
+from mybuild import core
 from util.namespace import Namespace
 
 
@@ -28,6 +29,10 @@ builtin_names = [
     # Constants
     'False', 'True', 'None',
 
+    # Mylang-specific
+    '__my_new_namespace__',
+    '__my_new_option__',
+
 
     # Disabled Python builtins:
     #
@@ -37,6 +42,17 @@ builtin_names = [
     # round setattr staticmethod super unichr unicode vars xrange __import__
     # apply buffer coerce intern
 ]
+
+def __my_new_namespace__(value, **kwargs):
+    return Namespace(__my_value__=value, **kwargs)
+
+_OPTION_TYPES = {
+    'string': core.Optype.str,
+    'number': core.Optype.int,
+    'boolean': core.Optype.bool,
+}
+def __my_new_option__(name, type_str, default=Ellipsis):
+    return _OPTION_TYPES[type_str](default=default).set(name=name)
 
 
 # Note that some name are taken from globals of this module (this includes

--- a/mybuild_embox/lang_legacy/runtime.py
+++ b/mybuild_embox/lang_legacy/runtime.py
@@ -1,0 +1,43 @@
+"""
+Runtime support for My-lang.
+"""
+from __future__ import print_function
+
+
+__author__ = "Eldar Abusalimov"
+__date__ = "2015-06-27"
+
+
+from _compat import *
+
+
+builtin_names = [
+    # Functions
+    'abs',        'all',        'any',        'bin',
+    'bool',       'dict',       'filter',     'float',
+    'format',     'getattr',    'hasattr',    'hex',
+    'id',         'int',        'isinstance', 'issubclass',
+    'iter',       'len',        'list',       'map',
+    'max',        'min',        'object',     'pow',
+    'print',      'range',      'repr',       'reversed',
+    'set',        'slice',      'sorted',     'str',
+    'sum',        'tuple',      'type',       'zip',
+
+    # Constants
+    'False', 'True', 'None',
+
+
+    # Disabled Python builtins:
+    #
+    # basestring bytearray callable chr classmethod compile complex delattr
+    # dir divmod enumerate eval execfile file frozenset globals hash help input
+    # locals long memoryview next oct open ord property raw_input reduce reload
+    # round setattr staticmethod super unichr unicode vars xrange __import__
+    # apply buffer coerce intern
+]
+
+
+# Note that some name are taken from globals of this module (this includes
+# _compat.* as well), and the rest come from Python builtins.
+builtins = dict((name, eval(name)) for name in builtin_names)
+


### PR DESCRIPTION
This adopts some basic rules from 'mylang.parse' module of embox/mybuild@59fcffdce789af55e45d46a035efaba759e0b3ff, primarily python-like expression: .attribute access, subscripts[] and calls().
