### PR TITLE
Add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,37 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='mybuild-embox',
+    version='0.1',
+
+    description='Build tools for Embox',
+    url='https://github.com/vloginova/mybuild-embox',
+
+    author='Vita Loginova',
+    author_email='vita.loginova@gmail.com',
+
+    license='BSD',
+
+    classifiers=[
+        'Private :: Do Not Upload',
+
+        'Development Status :: 3 - Alpha',
+
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Build Tools',
+
+        'License :: OSI Approved :: BSD License',
+
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+    ],
+    keywords='mybuild build automation development tools',
+
+    packages=find_packages(),
+
+    install_requires=['ply>=3.6'],
+)


### PR DESCRIPTION
This is mostly a stub to get pip installing it through absolute repo URL. Hence, the dependence on 'mybuild' is missing, since it has not been uploaded to PyPI yet.

Install into virtualenv using:

```
pip install git+https://github.com/embox/mybuild.git@embox-wip
pip install git+https://github.com/vloginova/mybuild-embox.git@master  # URL after merging this PR
```
